### PR TITLE
Fixed bug in GeoShapeWidget and GeoTraceWidget causing data loss.

### DIFF
--- a/app/src/main/java/com/geoodk/collect/android/widgets/GeoShapeWidget.java
+++ b/app/src/main/java/com/geoodk/collect/android/widgets/GeoShapeWidget.java
@@ -203,7 +203,7 @@ public class GeoShapeWidget extends QuestionWidget implements IBinaryWidget {
 			try {
 				String[] sa = s.split(";");
 				for (int i=0;i<sa.length;i++){
-					String[] sp = sa[i].split(" ");
+					String[] sp = sa[i].trim().split(" ");
 					double gp[] = new double[4];
 					gp[0] = Double.valueOf(sp[0]).doubleValue();
 					gp[1] = Double.valueOf(sp[1]).doubleValue();

--- a/app/src/main/java/com/geoodk/collect/android/widgets/GeoTraceWidget.java
+++ b/app/src/main/java/com/geoodk/collect/android/widgets/GeoTraceWidget.java
@@ -149,7 +149,7 @@ public class GeoTraceWidget extends QuestionWidget implements IBinaryWidget {
 			try {
 				String[] sa = s.split(";");
 				for (int i=0;i<sa.length;i++){
-					String[] sp = sa[i].split(" ");
+					String[] sp = sa[i].trim().split(" ");
 					double gp[] = new double[4];
 					gp[0] = Double.valueOf(sp[0]).doubleValue();
 					gp[1] = Double.valueOf(sp[1]).doubleValue();


### PR DESCRIPTION
If a user enters an already-bearing-data GeoShapeWidget or GeoTraceWidget, the IAnswerData is deleted upon swiping to another widget. If form is saved after browsing, dat is lost forever.

This is caused by an unneeded white-space in string representaion of IAnswerData in affected widgets. (Whitespace is added by org.javarosa.core.model.data.GeoShapreData.class)

Trimming trailing white-spaces from string representation of GeoPoint used in widgets saves from NumberFormatException while parsing the string back in a GeoPoint.
BEFORE FIX: " 9.43535 45.545645 0.0 0.0" --> split(" ") --> [" ","9.43535","45.545645","0.0","0.0"] --> Double.valueOf(" ") --> NumberFormatException --> failure in GeoPoint creation
AFTER FIX: " 9.43535 45.545645 0.0 0.0" --> trim() --> "9.43535 45.545645 0.0 0.0" --> split(" ") --> ["9.43535","45.545645","0.0","0.0"] --> Double.valueOf("9.43535") --> double --> correct GeoPoint creation